### PR TITLE
Refactor seeds.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
+  gem 'faker', '~> 1.4', '>= 1.4.3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
     diff-lcs (1.3)
     erubi (1.7.1)
     execjs (2.7.0)
+    faker (1.9.1)
+      i18n (>= 0.7)
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -191,6 +193,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   coffee-rails (~> 4.2)
+  faker (~> 1.4, >= 1.4.3)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
@@ -210,4 +213,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,12 +1,26 @@
-# Creating non-shipped orders.
-o1 = Order.create!()
-o2 = Order.create!()
-o3 = Order.create!()
-o4 = Order.create!()
-o5 = Order.create!()
-# Shipped at times are randomly assigned.  What great randomizaiton I've done!
-os1 = Order.create!(shipped_at: Time.now + 21.minute)
-os2 = Order.create!(shipped_at: Time.now + 20.minute)
-os3 = Order.create!(shipped_at: Time.now + 3.minute)
-os4 = Order.create!(shipped_at: Time.now + 40.minute)
-os5 = Order.create!(shipped_at: Time.now + 5.minute)
+# Generate Widgets using first_or_create to ensure no duplicates
+10.times do
+  name = Faker::Commerce.product_name
+  msrp = Faker::Commerce.price(range=1..50, as_string=false)
+
+  Widget.where(name: name).first_or_create!(msrp: msrp)
+end
+
+# Generate Orders with random shipped_at dates over the past year, along with some that have not yet shipped
+50.times do
+  now = Time.now
+  shipped_at = [nil, now - Faker::Number.between(1, 24).hours - Faker::Number.between(1, 365).days].sample
+
+  Order.create!(shipped_at: shipped_at)
+end
+
+# For each generated Order, create a random amount of LineItems using first_or_create to ensure no duplicates
+Order.all.each do |order|
+  Faker::Number.between(1, 5).times do
+    widget_id = Faker::Number.between(1, Widget.all.size)
+    quantity = Faker::Number.between(1, 10)
+    unit_price = Faker::Commerce.price(range=1..50, as_string=false)
+
+    LineItem.where(order: order, widget_id: widget_id).first_or_create!(quantity: quantity, unit_price: unit_price)
+  end
+end


### PR DESCRIPTION
The original `seeds.rb` file only generated Orders and had shipped_at dates in the future, so that `shipped_at > created_at` in some cases, which doesn't make much sense. This change updates the file to produce Widgets, Orders, and Line Items such that there are no duplicates rows and `shipped_at` is never greater than `created_at`.