### PR TITLE
Sorted Orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,9 @@
 class OrdersController < ApplicationController
   def index
     @orders = Order.all
+
+    @shipped_orders = Order.shipped.latest
+    @unshipped_orders = Order.unshipped
   end
 
   def show

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -20,4 +20,8 @@ class Order < ApplicationRecord
   def warehoused?
     @warehouse
   end
+
+  scope :shipped, -> { where('shipped_at is not null') }
+  scope :unshipped, -> { where('shipped_at is null') }
+  scope :latest, -> (column = :shipped_at) { order(column => :desc) }
 end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -3,12 +3,40 @@
     <title>Orders</title>
   </head>
   <body>
-    <h1>Orders</h1>
+    <div>
+      <h1>Shipped Orders</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Order Number</th>
+            <th>Shipped On:</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @shipped_orders.each do |order| %>
+            <tr>
+              <td><%= link_to order.id, order_path(order) %></td>
+              <td><%= order.shipped_at.strftime('%m/%d/%Y')%></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
 
-    <ul>
-    <% @orders.each do |order| %>
-      <li><%= link_to order.id, order_path(order) %></li>
-    <% end %>
-    </ul>
+      <h1>Unshipped Orders</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Order Number</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @unshipped_orders.each do |order| %>
+            <tr>
+              <td><%= link_to order.id, order_path(order) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </body>
 </html>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,8 +10,9 @@ end
 50.times do
   now = Time.now
   shipped_at = [nil, now - Faker::Number.between(1, 24).hours - Faker::Number.between(1, 365).days].sample
+  created_at = shipped_at - Faker::Number.between(1, 7).days if shipped_at
 
-  Order.create!(shipped_at: shipped_at)
+  Order.create!(shipped_at: shipped_at, created_at: created_at)
 end
 
 # For each generated Order, create a random amount of LineItems using first_or_create to ensure no duplicates

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -2,4 +2,8 @@ FactoryBot.define do
   factory :order do
     shipped_at { Time.now }
   end
+
+  trait :unshipped do
+    shipped_at { nil }
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -32,4 +32,62 @@ RSpec.describe Order, type: :model do
       it { is_expected.to be_warehoused }
     end
   end
+
+  describe 'shipped_at scopes' do
+    let!(:shipped_orders) { create_list(:order, 3) }
+    let!(:unshipped_orders) { create_list(:order, 3, :unshipped) }
+    
+    context ':shipped' do 
+      it 'filters out unshipped orders' do
+        expect(Order.shipped.size).to eq 3
+        expect(Order.shipped.all? { |order| order.shipped? }).to eq true
+      end
+    end
+
+    context ':unshipped' do 
+      it 'filters out shipped orders' do
+        expect(Order.unshipped.size).to eq 3
+        expect(Order.unshipped.all? { |order| !order.shipped? }).to eq true
+      end
+    end
+  end
+
+  describe 'latest scope' do
+    let(:shipped_orders) { [] }
+    let(:sorted_shipped) { [] }
+    let(:sorted_all) { [] }
+    let(:unshipped_orders) { create_list(:order, 3, :unshipped) }
+    let(:sorted_orders) { Order.order(:shipped_at) }
+
+    before do
+      3.times { shipped_orders << create(:order, shipped_at: Time.now + Random.rand(300).hours) }
+      sorted_shipped << shipped_orders.sort_by { |order| order.shipped_at }
+      sorted_all << (shipped_orders << unshipped_orders)
+    end
+
+    context ':latest' do
+      context 'when only scope' do
+        it 'orders by shipped_at column by default' do
+          expect(Order.latest).to match_array(sorted_all.flatten)
+        end
+
+        it 'orders by column passed in' do
+          sorted_by_created_at = Order.all.sort_by { |order| order.created_at }
+          expect(Order.latest(:created_at)).to match_array(sorted_by_created_at.flatten)
+        end
+      end
+
+      context 'when also shipped scope' do
+        it 'filters out unshipped_orders and sorts by shipped_at date' do
+          expect(Order.shipped.latest).to match_array(sorted_shipped.flatten)
+        end
+      end
+
+      context 'when also unshipped scope' do
+        it 'filters out shipped_orders and does not raise an error' do
+          expect(Order.unshipped.latest).to match_array(unshipped_orders)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Order, type: :model do
     let(:sorted_orders) { Order.order(:shipped_at) }
 
     before do
-      3.times { shipped_orders << create(:order, shipped_at: Time.now + Random.rand(300).hours) }
+      3.times { shipped_orders << create(:order, shipped_at: Time.now - Random.rand(300).hours) }
       sorted_shipped << shipped_orders.sort_by { |order| order.shipped_at }
       sorted_all << (shipped_orders << unshipped_orders)
     end


### PR DESCRIPTION
This PR adds scopes to the Order model that allow for easily pulling all shipped or unshipped orders and another for sorting by date passed into the scope (which uses shipped_at by default). I also updated the view to have two separate lists based on the shipment status and to display the shipped_at date for shipped orders. 

I realized as I was testing things that there were records in the database where the created_at date > shipped_at date. I still think it makes sense for all shipped_at dates to be in the past, but the created_at should come first. So, I made a small change to the `seeds.rb` file to update that.