### PR TITLE
Bugfix: Expedited Flag Cannot Be Updated

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,24 +1,19 @@
 class Order < ApplicationRecord
-  def expedited?
-    @expedite
-  end
-
-  def returnable?
-    @returns
-  end
-
-  def settings(opts = {})
-    @expedite = opts[:expedite].presence
-    @returns = opts[:returns].presence
-    @warehouse = opts[:warehouse].presence
-  end
 
   def shipped?
     shipped_at.present?
   end
 
+  def expedited?
+    expedite
+  end
+
+  def returnable?
+    returns
+  end
+
   def warehoused?
-    @warehouse
+    warehouse
   end
 
   scope :shipped, -> { where('shipped_at is not null') }

--- a/db/migrate/20181116144232_add_columns_to_orders.rb
+++ b/db/migrate/20181116144232_add_columns_to_orders.rb
@@ -1,0 +1,7 @@
+class AddColumnsToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :expedite, :boolean, default: false
+    add_column :orders, :returns, :boolean, default: false
+    add_column :orders, :warehouse, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_19_211334) do
+ActiveRecord::Schema.define(version: 2018_11_16_144232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,9 @@ ActiveRecord::Schema.define(version: 2018_10_19_211334) do
     t.datetime "shipped_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "expedite", default: false
+    t.boolean "returns", default: false
+    t.boolean "warehouse", default: false
   end
 
   create_table "widgets", force: :cascade do |t|


### PR DESCRIPTION
**Bug:** the expedited? flag on an order could not be changed once it was set.

**Thought Process:** If the desired behavior is just to be able to change the expedited? flag once it's been set originally, then we could add `attr_accessor :expedite, :warehouse, :returns` to the Order model and allow for getting and setting of these variables. However, the bug seems larger than that to me. The `expedite`, `returns`, and `warehouse` variables are set up currently as virtual attributes, which doesn't seem like the most desirable implementation. 

**Solution:** I ended up adding three boolean columns to the database `expedite`, `returns`, and `warehouse`. This allows for maintaining state in addition to making the data more accessible. I think this is the solution that makes the most sense because these fields don't seem like the right use case for virtual attributes. If an order is set to be expedited, the intended behavior is that it would remain in that state unless otherwise changed. I don't think these fields should be transient. 